### PR TITLE
BugFix #23 Scene is using the default constructor. Bumped release version to 0.0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Note that this library is brand-new and lacks a lot of features; I'm heavily wor
 
 Lots of neat features will follow soon!
 
-Installation: `[clojurefx "0.0.12"]`
+Installation: `[clojurefx "0.0.13"]`
 
 ### Short info about the state of the project
 Right now I'm rather busy and have a few things to do on a deadline. That's why there's little activity right now. Expect more activity in about one to two months. *I will not abandon this project*. Feel free to add stuff (including tests) and send pull requests - I will review them in about two days and accept them if they're allright.

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject clojurefx "0.0.13-SNAPSHOT"
+(defproject clojurefx "0.0.13"
   :description "Helper functions and probably a wrapper to simplify usage of JavaFX in Clojure.
 
   This is meant to be used with Java 8. If you add JavaFX 2.2 to your classpath it might still work, but that isn't tested.
   
   [This Project On GitHub](https://www.github.com/zilti/clojurefx)
 
-**Installation: `[clojurefx \"0.0.11\"]`**
+**Installation: `[clojurefx \"0.0.13\"]`**
 
 Navigation
 ----------

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojurefx "0.0.14-SNAPSHOT"
+(defproject clojurefx "0.0.13"
   :description "Helper functions and probably a wrapper to simplify usage of JavaFX in Clojure.
 
   This is meant to be used with Java 8. If you add JavaFX 2.2 to your classpath it might still work, but that isn't tested.
@@ -18,10 +18,10 @@ Navigation
   :lein-release {:deploy-via :clojars}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
-  :plugins [[lein-marginalia "0.8.0"]
-            [lein-midje "3.1.3"]
+  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :plugins [[lein-marginalia "0.7.1"]
+            [lein-midje "3.1.3-RC2"]
             [lein-release "1.0.5"]]
-  :profiles {:dev {:dependencies [[midje "1.6.3"]
+  :profiles {:dev {:dependencies [[midje "1.6-beta1"]
                                   [troncle "0.1.2-SNAPSHOT"]
-                                  [org.clojure/tools.trace "0.7.8"]]}})
+                                  [org.clojure/tools.trace "0.7.6"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojurefx "0.0.13"
+(defproject clojurefx "0.0.14-SNAPSHOT"
   :description "Helper functions and probably a wrapper to simplify usage of JavaFX in Clojure.
 
   This is meant to be used with Java 8. If you add JavaFX 2.2 to your classpath it might still work, but that isn't tested.
@@ -18,10 +18,10 @@ Navigation
   :lein-release {:deploy-via :clojars}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
-  :plugins [[lein-marginalia "0.7.1"]
-            [lein-midje "3.1.3-RC2"]
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :plugins [[lein-marginalia "0.8.0"]
+            [lein-midje "3.1.3"]
             [lein-release "1.0.5"]]
-  :profiles {:dev {:dependencies [[midje "1.6-beta1"]
+  :profiles {:dev {:dependencies [[midje "1.6.3"]
                                   [troncle "0.1.2-SNAPSHOT"]
-                                  [org.clojure/tools.trace "0.7.6"]]}})
+                                  [org.clojure/tools.trace "0.7.8"]]}})

--- a/src/clojurefx/core.clj
+++ b/src/clojurefx/core.clj
@@ -436,7 +436,7 @@ Don't use this yourself; See the macros \"fx\" and \"deffx\" below.
   `(defmethod construct-node '~clazz [cl# ar#]
      (apply constructor-helper cl# (for [k# ~keys] (get ar# k#)))))
 
-(defmulti construct-node (fn [class args] (resolve class)))
+(defmulti construct-node (fn [class args] class))
 (defmethod construct-node :default [class _]
   (run-now (eval `(new ~class)))
   )

--- a/src/clojurefx/core.clj
+++ b/src/clojurefx/core.clj
@@ -100,6 +100,9 @@ Runs the code on the FX application thread and waits until the return value is d
 
 ;; ## Collection helpers
 ;; This probably isn't the ideal approach for mutable collections. Check back for better ones.
+(defn list->observable [l]
+   (javafx.collections.FXCollections/observableArrayList l))
+
 (defn seq->observable [s]
   (javafx.collections.FXCollections/unmodifiableObservableList s))
 
@@ -110,14 +113,15 @@ Runs the code on the FX application thread and waits until the return value is d
   (javafx.collections.FXCollections/unmodifiableObservableSet s))
 
 ;; Argument wrapping
-(defmulti wrap-arg "Autoboxing-like behaviour for arguments for ClojureFX nodes." (fn [arg class] arg))
+(defmulti wrap-arg "Autoboxing-like behaviour for arguments for ClojureFX nodes." (fn [arg# clazz] [(key arg#) clazz]))
 
-(defmethod wrap-arg :default [arg class] arg)
+(defmethod wrap-arg :default [arg# clazz] (val arg#))
 
-(defmethod wrap-arg :accelerator [arg _]
-  (if (string? arg)
-    (javafx.scene.input.KeyCombination/keyCombination arg)
-    arg))
+(defmethod wrap-arg :accelerator [arg# clazz]
+   (let [arg (val arg#)]
+      (if (string? arg)
+         (javafx.scene.input.KeyCombination/keyCombination arg)
+         arg)))
 
 ;; ## <a name="databinding"></a> Data binding
 (defmulti bidirectional-bind-property! (fn [type obj prop & args] type))
@@ -330,6 +334,7 @@ The listener gets a preprocessed event map as shown above.
 (def-simple-swapper javafx.scene.control.TreeItem .getChildren .setAll)
 (def-simple-swapper javafx.scene.control.TreeTableColumn .getColumns .setAll)
 (def-simple-swapper javafx.scene.shape.Path .getElements .setAll)
+(def-simple-swapper javafx.scene.chart.PieChart .getData .setAll)
 
 (defmethod swap-content!* javafx.scene.control.SplitPane [obj fun]
   (let [data {:items (into [] (.getItems obj))
@@ -474,7 +479,7 @@ Don't use this yourself; See the macros \"fx\" and \"deffx\" below.
         obj# (construct-node qualified-name# args#)]
     (run-now (doseq [arg# args#] ;; Apply arguments
                (if (contains? methods# (key arg#))
-                 (((key arg#) methods#) obj# (wrap-arg (val arg#) (type obj#)))))
+                 (((key arg#) methods#) obj# (wrap-arg arg# (type obj#)))))
              (doseq [prop# props#] ;; Bind properties
                (bind-property!* obj# (key prop#) (val prop#)))
              (doseq [listener# listeners#] ;; Add listeners
@@ -506,8 +511,8 @@ Special keys:
 
 (construct javafx.stage.Stage [:stage-style])
 
-(defmethod wrap-arg :stage-style [arg class]
-  (clojure.lang.Reflector/getStaticField javafx.stage.StageStyle (-> arg name str/upper-case)))
+(defmethod wrap-arg [:stage-style javafx.stage.Stage] [arg# class]
+  (clojure.lang.Reflector/getStaticField javafx.stage.StageStyle (-> (val arg#) name str/upper-case)))
 
 (defmethod swap-content!* javafx.stage.Stage [obj fun]
   (.setScene obj (fun (.getScene obj))))
@@ -516,8 +521,8 @@ Special keys:
 
 (construct javafx.scene.Scene [:root :width :height :depth-buffer :scene-antialiasing])
 
-(defmethod wrap-arg :scene-antialiasing [arg class]
-  (clojure.lang.Reflector/getStaticField javafx.scene.SceneAntialiasing (-> arg name str/upper-case)))
+(defmethod wrap-arg [:scene-antialiasing javafx.scene.Scene] [arg# class]
+  (clojure.lang.Reflector/getStaticField javafx.scene.SceneAntialiasing (-> (val arg#) name str/upper-case)))
 
 (defmethod swap-content!* javafx.scene.Scene [obj fun]
   (.setRoot obj (fun (.getRoot obj))))
@@ -633,11 +638,14 @@ Special keys:
 
 ;; ### Table view
 
-(defmethod wrap-arg :items javafx.scene.control.TableView [arg clazz]
-  (seq->observable arg))
+(defmethod wrap-arg [:data javafx.scene.chart.PieChart] [arg# clazz]
+  (list->observable (val arg#)))
 
-(defmethod wrap-arg :columns javafx.scene.control.TableView [arg clazz]
-  (seq->observable arg))
+(defmethod wrap-arg [:items javafx.scene.control.TableView] [arg# clazz]
+  (seq->observable (val arg#)))
+
+(defmethod wrap-arg [:columns javafx.scene.control.TableView] [arg# clazz]
+  (seq->observable (val arg#)))
 
 (defmethod swap-content!* javafx.scene.control.TableView [obj fun]
   (let [data {:items (into [] (.getItems obj))


### PR DESCRIPTION
Scene is using the default constructor when it should use the...already define specific to Scene

Scene needs the root in the constructor whereas the default constructor does not use any parameter.
