### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/core.async {:mvn/version "0.7.559"}
-        camel-snake-kebab {:mvn/version "0.4.1"}
+        camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.1"}
         com.taoensso/timbre {:mvn/version "4.10.0"}
         org.openjfx/javafx-fxml {:mvn/version "13.0.2"}}
  :paths ["src" "classes"]


### PR DESCRIPTION
Unqualified lib names are being deprecated in deps.edn and will warn